### PR TITLE
Replace primary constructors with explicit ones

### DIFF
--- a/HeicJpegToolkit/Helpers/Options/ConversionOptions.cs
+++ b/HeicJpegToolkit/Helpers/Options/ConversionOptions.cs
@@ -1,3 +1,5 @@
+using HeicJpegToolkit.Helpers.Enums;
+
 namespace HeicJpegToolkit.Helpers.Options
 {
     /// <summary>

--- a/HeicJpegToolkit/Structures/Resolution.cs
+++ b/HeicJpegToolkit/Structures/Resolution.cs
@@ -1,8 +1,14 @@
-﻿namespace HeicJpegToolkit.Structures
+namespace HeicJpegToolkit.Structures
 {
-    public readonly struct Resolution(double dpiX, double dpiY)
+    public readonly struct Resolution
     {
-        public double DpiX { get; } = dpiX;
-        public double DpiY { get; } = dpiY;
+        public double DpiX { get; }
+        public double DpiY { get; }
+
+        public Resolution(double dpiX, double dpiY)
+        {
+            DpiX = dpiX;
+            DpiY = dpiY;
+        }
     }
 }

--- a/HeicJpegToolkit/Structures/WICBlob.cs
+++ b/HeicJpegToolkit/Structures/WICBlob.cs
@@ -1,7 +1,12 @@
-﻿namespace HeicJpegToolkit.Structures
+namespace HeicJpegToolkit.Structures
 {
-    public class WICBlob(byte[] bytes)
+    public class WICBlob
     {
-        public byte[] Bytes { get; } = bytes;
+        public byte[] Bytes { get; }
+
+        public WICBlob(byte[] bytes)
+        {
+            Bytes = bytes;
+        }
     }
 }

--- a/HeicJpegToolkit/Structures/WICSize.cs
+++ b/HeicJpegToolkit/Structures/WICSize.cs
@@ -1,9 +1,15 @@
-﻿namespace HeicJpegToolkit.Structures
+namespace HeicJpegToolkit.Structures
 {
-    public readonly struct WICSize(int width, int height) : IEquatable<WICSize>
+    public readonly struct WICSize : IEquatable<WICSize>
     {
-        public int Width { get; } = width;
-        public int Height { get; } = height;
+        public int Width { get; }
+        public int Height { get; }
+
+        public WICSize(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
 
         public override bool Equals(object? obj)
         {


### PR DESCRIPTION
Convert C# primary-constructor style declarations into explicit constructors and property initializers for Resolution, WICSize, and WICBlob to improve clarity and compatibility. Also add a missing using (HeicJpegToolkit.Helpers.Enums) in ConversionOptions.cs. Affected files: Structures/Resolution.cs, Structures/WICSize.cs, Structures/WICBlob.cs, and Helpers/Options/ConversionOptions.cs.